### PR TITLE
Fix call_user_func call in ObjectRelationsGetterExtractor

### DIFF
--- a/src/DsTrinityDataBundle/Resource/FieldTransformer/Object/ObjectRelationsGetterExtractor.php
+++ b/src/DsTrinityDataBundle/Resource/FieldTransformer/Object/ObjectRelationsGetterExtractor.php
@@ -60,7 +60,7 @@ class ObjectRelationsGetterExtractor implements FieldTransformerInterface
                 return null;
             }
 
-            $values[] = call_user_func([$relation, $this->options['method'], $this->options['arguments']]);
+            $values[] = call_user_func([$relation, $this->options['method']], $this->options['arguments']);
         }
 
         return $values;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #8

Fixes wrong placement of brackets in a call_user_func invocation.